### PR TITLE
Try enable redis-yml recipe.

### DIFF
--- a/cookbooks/main/recipes/default.rb
+++ b/cookbooks/main/recipes/default.rb
@@ -14,7 +14,6 @@
 # include_recipe "ban"
 
 # uncomment to use the sidekiq recipe. See cookbooks/sidekiq/readme.md for documentation.
-include_recipe "redis"
 include_recipe "sidekiq"
 
 #uncomment to turn on memcached
@@ -55,12 +54,13 @@ include_recipe "sidekiq"
 # include_recipe "resque"
 
 #uncomment to run redis.yml recipe
-# include_recipe "redis-yml"
+include_recipe "redis-yml"
 
 #uncomment to run the resque-scheduler recipe
 # include_recipe "resque-scheduler"
 
 #uncomment to run the redis recipe
+include_recipe "redis"
 
 #uncomment to run the api-keys-yml recipe
 # include_recipe "api-keys-yml"


### PR DESCRIPTION
This should allow us to use a redis.yml both in dev/test and have the
production ones overwrite the dev ones on deploy.
